### PR TITLE
EFRepositoryonlyBase - if entity had to be attached, we do set its st…

### DIFF
--- a/src/Abp.EntityFramework/Abp.EntityFramework.csproj
+++ b/src/Abp.EntityFramework/Abp.EntityFramework.csproj
@@ -16,6 +16,18 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <RootNamespace>Abp</RootNamespace>
+	  <RepositoryUrl>https://github.com/Opti-Q/aspnetboilerplate.git</RepositoryUrl> 
+	  <RepositoryType>git</RepositoryType> 
+	  <Version>2.3.1-optiq0001</Version>
+	  <Authors>amarek</Authors>
+	  <Company>Opti-Q GmbH</Company>
+	  <PackageReleaseNotes>
+		  # 2.3.1-optiq0001
+		  - EFRepositoryonlyBase - if entity had to be attached, we do set its state to "Modified" this ensures, that unnecessary calls to "UpdateAsync" result in the whole entity being set "dirty" as opposed to just the properties that changed!
+
+	      # 2.3.1
+			... base package
+	  </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Abp.EntityFramework/EntityFramework/Repositories/EfRepositoryBaseOfTEntityAndTPrimaryKey.cs
+++ b/src/Abp.EntityFramework/EntityFramework/Repositories/EfRepositoryBaseOfTEntityAndTPrimaryKey.cs
@@ -180,15 +180,23 @@ namespace Abp.EntityFramework.Repositories
 
         public override TEntity Update(TEntity entity)
         {
-            AttachIfNot(entity);
-            Context.Entry(entity).State = EntityState.Modified;
+            // only if entity had to be attached, we do set its state to "Modified"
+            // this ensures, that unnecessary calls to "Update" result in the whole entity being set "dirty"
+            // as opposed to just the properties that changed!
+            if(AttachIfNot(entity))
+                Context.Entry(entity).State = EntityState.Modified;
+            
             return entity;
         }
-
+        
         public override Task<TEntity> UpdateAsync(TEntity entity)
         {
-            AttachIfNot(entity);
-            Context.Entry(entity).State = EntityState.Modified;
+            // only if entity had to be attached, we do set its state to "Modified"
+            // this ensures, that unnecessary calls to "UpdateAsync" result in the whole entity being set "dirty"
+            // as opposed to just the properties that changed!
+            if(AttachIfNot(entity))
+                Context.Entry(entity).State = EntityState.Modified;
+
             return Task.FromResult(entity);
         }
 
@@ -233,12 +241,15 @@ namespace Abp.EntityFramework.Repositories
             return await GetAll().Where(predicate).LongCountAsync();
         }
 
-        protected virtual void AttachIfNot(TEntity entity)
+        protected virtual bool AttachIfNot(TEntity entity)
         {
             if (!Table.Local.Contains(entity))
             {
                 Table.Attach(entity);
+                return true;
             }
+
+            return false;
         }
 
         public DbContext GetDbContext()


### PR DESCRIPTION
…ate to "Modified"

this ensures, that unnecessary calls to "UpdateAsync" result in the whole entity being set "dirty" as opposed to just the properties that changed!